### PR TITLE
Faux Hollows Weekly

### DIFF
--- a/src/data/items.js
+++ b/src/data/items.js
@@ -183,5 +183,14 @@ export const List = {
 			tags: ["DoW", "DoM"],
 			isCompleted: false
 		},
+		{
+			name: "Faux Hollows (Unreal Trials)",
+			links:[
+				{ source:: "cgw", url: "https://ffxiv.consolegameswiki.com/wiki/Faux_Hollows"},
+				{ source:: "ge", url: "https://ffxiv.gamerescape.com/wiki/Faux_Hollows"}
+			],
+			tags: ["DoW"],
+			isCompleted: false
+		}
 	]
 };


### PR DESCRIPTION
Unreal Trials (or rather the faux hollows minigame) is limited to 2 times a week.